### PR TITLE
added inline style to anchor tags with classname as social-links

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,7 +160,7 @@
     <div class="row pt-5 social-container">
 
       <!-- &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -->
-      <a href="/" class="social-links">
+      <a href="/" class="social-links" style="text-decoration: none;">
         <div class="col-3 contact_link btn">
           <div class="row">
             <div class="col-6 d-flex justify-content-start">
@@ -174,7 +174,7 @@
       </a>
        <!-- &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -->
 
-      <a href="/" class="social-links">
+      <a href="/" class="social-links" style="text-decoration: none;">
         <div class="col-3 contact_link btn">
           <div class="row">
             <div class="col-6 d-flex justify-content-start">
@@ -188,7 +188,7 @@
       </a>
        <!-- &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -->
 
-      <a href="/" class="social-links">
+      <a href="/" class="social-links" style="text-decoration: none;">
         <div class="col-3 contact_link btn">
           <div class="row">
             <div class="col-6 d-flex justify-content-start">
@@ -202,7 +202,7 @@
       </a>
        <!-- &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; -->
 
-      <a href="/" class="social-links">
+      <a href="/" class="social-links" style="text-decoration: none;">
         <div class="col-3 contact_link btn">
           <div class="row">
             <div class="col-6 d-flex justify-content-start">

--- a/styles/style.css
+++ b/styles/style.css
@@ -101,11 +101,13 @@ h5 {
     display: flex;
     align-items: center;
     justify-content: center;
+    
 }
 .social-links{
     margin-left: 3rem;
     margin-right: 3rem;
     margin-top: 2rem;
+    
 }
 .contact_link, .row{
     display: flex;


### PR DESCRIPTION
Previously the text of the social link on hover was displayed underlined making it look slightly unpresentable.
My commit removes the underline by adding inline CSS and now it looks more presentable!